### PR TITLE
Add !default for all variables

### DIFF
--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -4,120 +4,120 @@
 //PATHS
 //--------------------------------------------------------
 
-$boxed-layout-bg-image-path: "../img/boxed-bg.png";
+$boxed-layout-bg-image-path: "../img/boxed-bg.png" !default;
 
 //COLORS
 //--------------------------------------------------------
 //Primary
-$light-blue: #3c8dbc;
+$light-blue: #3c8dbc !default;
 //Danger
-$red: #dd4b39;
+$red: #dd4b39 !default;
 //Success
-$green: #00a65a;
+$green: #00a65a !default;
 //Info
-$aqua: #00c0ef;
+$aqua: #00c0ef !default;
 //Warning
-$yellow: #f39c12;
-$blue: #1a1c22;
-$navy: #001F3F;
-$teal: #39CCCC;
-$olive: #3D9970;
-$lime: #01FF70;
-$orange: #FF851B;
-$fuchsia: #F012BE;
-$purple: #605ca8;
-$maroon: #D81B60;
-$black: #111;
-$gray: #d2d6de;
+$yellow: #f39c12 !default;
+$blue: #1a1c22 !default;
+$navy: #001F3F !default;
+$teal: #39CCCC !default;
+$olive: #3D9970 !default;
+$lime: #01FF70 !default;
+$orange: #FF851B !default;
+$fuchsia: #F012BE !default;
+$purple: #605ca8 !default;
+$maroon: #D81B60 !default;
+$black: #111 !default;
+$gray: #d2d6de !default;
 
 //LAYOUT
 //--------------------------------------------------------
 
 //Side bar and logo width
-$sidebar-width: 230px;
+$sidebar-width: 230px !default;
 //Boxed layout maximum width
-$boxed-layout-max-width: 1024px;
+$boxed-layout-max-width: 1024px !default;
 //When the logo should go to the top of the screen
-$screen-header-collapse: $screen-xs-max;
+$screen-header-collapse: $screen-xs-max !default;
 
 //Link colors (Aka: <a> tags)
-$link-color: $light-blue;
-$link-hover-color: lighten($link-color, 15%);
+$link-color: $light-blue !default;
+$link-hover-color: lighten($link-color, 15%) !default;
 
 //Body background (Affects main content background only)
-$body-bg: #ecf0f5;
+$body-bg: #ecf0f5 !default;
 
 //SIDEBAR SKINS
 //--------------------------------------------------------
 
 //Dark sidebar
-$sidebar-dark-bg: #222d32;
-$sidebar-dark-hover-bg: darken($sidebar-dark-bg, 2%);
-$sidebar-dark-color: lighten($sidebar-dark-bg, 60%);
-$sidebar-dark-hover-color: #fff;
-$sidebar-dark-submenu-bg: lighten($sidebar-dark-bg, 5%);
-$sidebar-dark-submenu-color: lighten($sidebar-dark-submenu-bg, 40%);
-$sidebar-dark-submenu-hover-color: #fff;
+$sidebar-dark-bg: #222d32 !default;
+$sidebar-dark-hover-bg: darken($sidebar-dark-bg, 2%) !default;
+$sidebar-dark-color: lighten($sidebar-dark-bg, 60%) !default;
+$sidebar-dark-hover-color: #fff !default;
+$sidebar-dark-submenu-bg: lighten($sidebar-dark-bg, 5%) !default;
+$sidebar-dark-submenu-color: lighten($sidebar-dark-submenu-bg, 40%) !default;
+$sidebar-dark-submenu-hover-color: #fff !default;
 
 //Light sidebar
-$sidebar-light-bg: #f9fafc;
-$sidebar-light-hover-bg: lighten(#f0f0f1, 1.5%);
-$sidebar-light-color: #444;
-$sidebar-light-hover-color: #000;
-$sidebar-light-submenu-bg: $sidebar-light-hover-bg;
-$sidebar-light-submenu-color: #777;
-$sidebar-light-submenu-hover-color: #000;
+$sidebar-light-bg: #f9fafc !default;
+$sidebar-light-hover-bg: lighten(#f0f0f1, 1.5%) !default;
+$sidebar-light-color: #444 !default;
+$sidebar-light-hover-color: #000 !default;
+$sidebar-light-submenu-bg: $sidebar-light-hover-bg !default;
+$sidebar-light-submenu-color: #777 !default;
+$sidebar-light-submenu-hover-color: #000 !default;
 
 //CONTROL SIDEBAR
 //--------------------------------------------------------
-$control-sidebar-width: $sidebar-width;
+$control-sidebar-width: $sidebar-width !default;
 
 //BOXES
 //--------------------------------------------------------
-$box-border-color: #f4f4f4;
-$box-border-radius: 3px;
-$box-footer-bg: #f6f6f6;
-$box-boxshadow: 0 1px 1px rgba(0, 0, 0, .1);
-$box-padding: 10px;
+$box-border-color: #f4f4f4 !default;
+$box-border-radius: 3px !default;
+$box-footer-bg: #f6f6f6 !default;
+$box-boxshadow: 0 1px 1px rgba(0, 0, 0, .1) !default;
+$box-padding: 10px !default;
 
 //Box variants
-$box-default-border-top-color: #d2d6de;
+$box-default-border-top-color: #d2d6de !default;
 
 //BUTTONS
 //--------------------------------------------------------
-$btn-boxshadow: none;
+$btn-boxshadow: none !default;
 
 //PROGRESS BARS
 //--------------------------------------------------------
-$progress-bar-border-radius: 1px;
-$progress-bar-sm-border-radius: 1px;
-$progress-bar-xs-border-radius: 1px;
+$progress-bar-border-radius: 1px !default;
+$progress-bar-sm-border-radius: 1px !default;
+$progress-bar-xs-border-radius: 1px !default;
 
 //FORMS
 //--------------------------------------------------------
-$input-radius: 0;
+$input-radius: 0 !default;
 
 //BUTTONS
 //--------------------------------------------------------
 
 //Border radius for non flat buttons
-$btn-border-radius: 3px;
+$btn-border-radius: 3px !default;
 
 //DIRECT CHAT
 //--------------------------------------------------------
-$direct-chat-height: 250px;
-$direct-chat-default-msg-bg: $gray;
-$direct-chat-default-font-color: #444;
-$direct-chat-default-msg-border-color: $gray;
+$direct-chat-height: 250px !default;
+$direct-chat-default-msg-bg: $gray !default;
+$direct-chat-default-font-color: #444 !default;
+$direct-chat-default-msg-border-color: $gray !default;
 
 //CHAT WIDGET
 //--------------------------------------------------------
-$attachment-border-radius: 3px;
+$attachment-border-radius: 3px !default;
 
 //TRANSITIONS SETTINGS
 //--------------------------------------------------------
 
 //Transition global options
-$transition-speed: .3s;
-$transition-fn: ease-in-out;
-//cubic-bezier(0.32,1.25,0.375,1.15);
+$transition-speed: .3s !default;
+$transition-fn: ease-in-out !default;
+//cubic-bezier(0.32,1.25,0.375,1.15) !default;


### PR DESCRIPTION
Currently if you wish to override a variable you must either rewrite `AdminLTE.scss` and include your custom `_variables.scss` or modify the `_variables.scss` in `node_modules`, which is bad practice. This way, you can set variables before import, and the variables persist throughout the rest of the stylesheet.