### PR TITLE
Fix $blue hex color

### DIFF
--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -18,7 +18,7 @@ $green: #00a65a;
 $aqua: #00c0ef;
 //Warning
 $yellow: #f39c12;
-$blue: #1a1c22;
+$blue: #3c8dbc;
 $navy: #001F3F;
 $teal: #39CCCC;
 $olive: #3D9970;


### PR DESCRIPTION
Hexadecimal color for ```$blue``` variable was wrongly set to black